### PR TITLE
Long strings are no longer split to multiple lines on serialization

### DIFF
--- a/src/Innofactor.Xrm.Json.Serialization.Tests/EntityConverterTests.cs
+++ b/src/Innofactor.Xrm.Json.Serialization.Tests/EntityConverterTests.cs
@@ -75,7 +75,8 @@
             value.Attributes.Add("attribute1", new OptionSetValue(1));
             value.Attributes.Add("attribute2", 2);
             value.Attributes.Add("attribute3", 13.37d);
-            var expected = $"{{\"_reference\":\"{name}:{id.ToString()}\",\"attribute1\":{{\"_option\":1}},\"attribute2\":2,\"attribute3\":13.37}}";
+            value.Attributes.Add("attribute4", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            var expected = $"{{\"_reference\":\"{name}:{id.ToString()}\",\"attribute1\":{{\"_option\":1}},\"attribute2\":2,\"attribute3\":13.37,\"attribute4\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}}";
 
             // Act
             var actual = JsonConvert.SerializeObject(value, Formatting.None, new EntityConverter());

--- a/src/Innofactor.Xrm.Json.Serialization/BasicsConverter.cs
+++ b/src/Innofactor.Xrm.Json.Serialization/BasicsConverter.cs
@@ -60,7 +60,7 @@
                 {
                     using (var provider = CodeDomProvider.CreateProvider("CSharp"))
                     {
-                        provider.GenerateCodeFromExpression(new CodePrimitiveExpression(value.ToString()), converter, null);
+                        provider.GenerateCodeFromExpression(new CodeSnippetExpression($"\"{value}\""), converter, null);
                         writer.WriteRawValue(converter.ToString());
                     }
                 }


### PR DESCRIPTION
added a unit test and modified the basicvoncerter such that long string are not split to "aaaa" + "aaaa" and are instead left as "aaaaaaaa"